### PR TITLE
fix: deploy cloud9 in workshop subnet

### DIFF
--- a/static/rke2-eks-cluster-workshop.yaml
+++ b/static/rke2-eks-cluster-workshop.yaml
@@ -1039,6 +1039,7 @@ Resources:
       ImageId: 'amazonlinux-2-x86_64'
       InstanceType: 't2.medium'
       Name: 'AWS-RGS-Workshop'
+      SubnetId: !Ref RancherPublicSubnet1
 
   KMSSecretsKey:
     Type: AWS::KMS::Key

--- a/static/rke2-eks-cluster.yaml
+++ b/static/rke2-eks-cluster.yaml
@@ -1036,6 +1036,7 @@ Resources:
       ImageId: 'amazonlinux-2-x86_64'
       InstanceType: 't2.medium'
       Name: 'AWS-RGS-Workshop'
+      SubnetId: !Ref RancherPublicSubnet1
 
   KMSSecretsKey:
     Type: AWS::KMS::Key


### PR DESCRIPTION
*Description of changes:*

No subnet associated with Cloud9, used the next available default VPC and default Subnet. Connection issues will cause the Stack to fail and Rollback, either caused by an IP overlap or usage of a non public subnet.

https://docs.aws.amazon.com/cloud9/latest/user-guide/troubleshooting.html#docker-bridge https://docs.aws.amazon.com/cloud9/latest/user-guide/vpc-settings.html?icmpid=docs_ac9_console#vpc-settings-requirements

Setting it to 'RancherPublicSubnet1' avoids the above problems, especially in non Workshop Engine Accounts.

*Issue #, if available:*

relates https://github.com/aws-samples/rancher-on-aws-workshop/issues/32

-----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
