### PR TITLE
upgraded ami for new versions

### DIFF
--- a/static/rke2-eks-cluster-workshop.yaml
+++ b/static/rke2-eks-cluster-workshop.yaml
@@ -39,7 +39,7 @@ Parameters:
   WorkshopC9InstanceVolumeSize:
     Type: Number
     Description: The Size in GB of the Cloud9 Instance Volume.
-    Default: 24
+    Default: 32
   RancherClusterToken:
     Description: "Cluster Join Token for RKE2 Cluster (Default: Pa22word)"
     Type: String

--- a/static/rke2-eks-cluster-workshop.yaml
+++ b/static/rke2-eks-cluster-workshop.yaml
@@ -64,7 +64,9 @@ Parameters:
 Mappings:
   AWSRegionArch2AMI:
     us-east-1:
-      HVM64: ami-0fbb7dc61be0ac719
+      HVM64: ami-0c5e3d1f21d6ce27f
+    us-west-2:
+      HVM64: ami-06980da992b300927
 
 Resources:
   ######

--- a/static/rke2-eks-cluster.yaml
+++ b/static/rke2-eks-cluster.yaml
@@ -39,7 +39,7 @@ Parameters:
   WorkshopC9InstanceVolumeSize:
     Type: Number
     Description: The Size in GB of the Cloud9 Instance Volume.
-    Default: 24
+    Default: 32
   RancherClusterToken:
     Description: "Cluster Join Token for RKE2 Cluster (Default: Pa22word)"
     Type: String

--- a/static/rke2-eks-cluster.yaml
+++ b/static/rke2-eks-cluster.yaml
@@ -64,7 +64,9 @@ Parameters:
 Mappings:
   AWSRegionArch2AMI:
     us-east-1:
-      HVM64: ami-0fbb7dc61be0ac719
+      HVM64: ami-0c5e3d1f21d6ce27f
+    us-west-2:
+      HVM64: ami-06980da992b300927
 
 Resources:
   ######


### PR DESCRIPTION
* Updated AWS AMI for Rancher v2.7.5 ([release notes](https://github.com/rancher/rancher/releases/tag/v2.7.5)) and RKE2 v1.24.15 ([release notes](https://github.com/rancher/rke2/releases/tag/v1.24.15+rke2r1))
* Updated EC2 Instance Sizing from 24 Gi to 32 Gi
* Tested and Verified comparability with the workshop environment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.