### PR TITLE
updated amis for rancher

### DIFF
--- a/static/rke2-eks-cluster-workshop.yaml
+++ b/static/rke2-eks-cluster-workshop.yaml
@@ -64,9 +64,9 @@ Parameters:
 Mappings:
   AWSRegionArch2AMI:
     us-east-1:
-      HVM64: ami-016c45a93aca83660
+      HVM64: ami-0952d52af14727a0c
     us-west-2:
-      HVM64: ami-0c53d23fce92bc664
+      HVM64: ami-02c9e452bc50f23dc
 
 Resources:
   ######

--- a/static/rke2-eks-cluster.yaml
+++ b/static/rke2-eks-cluster.yaml
@@ -64,9 +64,9 @@ Parameters:
 Mappings:
   AWSRegionArch2AMI:
     us-east-1:
-      HVM64: ami-016c45a93aca83660
+      HVM64: ami-0952d52af14727a0c
     us-west-2:
-      HVM64: ami-0c53d23fce92bc664
+      HVM64: ami-02c9e452bc50f23dc
 
 Resources:
   ######


### PR DESCRIPTION
* Updated AWS AMI for Rancher Manager v2.7.6 (emergency break fix... [release notes](https://github.com/rancher/rancher/releases/tag/v2.7.6))
  * From the release notes: *"All users should skip upgrading to 2.7.5 and immediately upgrade to 2.7.6."*
* Tested and verified comparability with the workshop environment on two accounts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
