### PR TITLE
Changed the DependsOn value for the RancherELB to PublicGatewayAttach…

### DIFF
--- a/static/rke2-eks-cluster-workshop.yaml
+++ b/static/rke2-eks-cluster-workshop.yaml
@@ -847,7 +847,7 @@ Resources:
         Timeout: '5'
 
   RancherELB:
-    DependsOn: PublicInternetGateway
+    DependsOn: PublicGatewayAttachment
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
       Subnets:

--- a/static/rke2-eks-cluster.yaml
+++ b/static/rke2-eks-cluster.yaml
@@ -847,7 +847,7 @@ Resources:
         Timeout: '5'
 
   RancherELB:
-    DependsOn: PublicInternetGateway
+    DependsOn: PublicGatewayAttachment
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
       Subnets:


### PR DESCRIPTION
…ment

Issue: Creating a stack was failing due to timing of the IGW to VPC attachment and RancherELB being created.  
Description of changes: Replaced DependsOn value from PublicInternetGateway to PublicGatewayAttachment to ensure the RancherELB wouldnt fail to create due to a VPC without an IGW.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
